### PR TITLE
Add DataFilterArgs.pageSize and .extras

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-iotile-cloud",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Angular IOTile Cloud interface",
   "main": "ng-iotile-cloud.js",
   "scripts": {

--- a/src/iotile/cloud.service.ts
+++ b/src/iotile/cloud.service.ts
@@ -424,7 +424,8 @@ export class CloudService {
           result.push(new DataPoint(item));
         });
       }
-      let page: DataPage = new DataPage(1000, data['count'], args.page || 1);
+      let pageSize: number = args.pageSize || 1000;
+      let page: DataPage = new DataPage(pageSize, data['count'], args.page || 1);
       page.data = result;
       return page;
     }).subscribe(

--- a/src/iotile/models/datafilterargs.ts
+++ b/src/iotile/models/datafilterargs.ts
@@ -8,6 +8,7 @@ export class DataFilterArgs {
   public pageSize: number;
   public startIncrementalId: number;
   public endIncrementalId: number;
+  public extras: Array<string>;
 
   public buildFilterString(): string {
 
@@ -40,6 +41,11 @@ export class DataFilterArgs {
     }
     if (this.endIncrementalId) {
       parameters.push('streamer_id_1=' + this.endIncrementalId);
+    }
+    if (this.extras && this.extras.length > 0) {
+      this.extras.forEach(p => {
+        parameters.push(p);
+      });
     }
     if (parameters.length) {
       let dataFilter: string = '?' + parameters.join('&');

--- a/src/iotile/models/datafilterargs.ts
+++ b/src/iotile/models/datafilterargs.ts
@@ -5,6 +5,7 @@ export class DataFilterArgs {
   public endDate: Date;
   public lastN: number;
   public page: number;
+  public pageSize: number;
   public startIncrementalId: number;
   public endIncrementalId: number;
 
@@ -27,6 +28,9 @@ export class DataFilterArgs {
     }
     if (this.page) {
       parameters.push('page=' + this.page);
+    }
+    if (this.pageSize) {
+      parameters.push('page_size=' + this.pageSize);
     }
     if (this.filter) {
       parameters.push('filter=' + this.filter);

--- a/src/test/models/datafilterargs.spec.ts
+++ b/src/test/models/datafilterargs.spec.ts
@@ -40,6 +40,20 @@ describe('DataFilterArgsTest', () => {
       expect(filter_string).toEqual(`?end=`+end+`&filter=${streamSlugMock}`);
     });
 
+    it ('should build filter with extras', () => {
+      let args = new DataFilterArgs();
+      args.filter = streamSlugMock;
+      args.extras = ['staff=1'];
+      let filter_string = args.buildFilterString();
+      let end = args.endDate.toISOString();
+      expect(filter_string).toEqual(`?end=`+end+`&filter=${streamSlugMock}`+'&staff=1');
+      
+      args.extras = ['a=b', 'c=d'];
+      filter_string = args.buildFilterString();
+      end = args.endDate.toISOString();
+      expect(filter_string).toEqual(`?end=`+end+`&filter=${streamSlugMock}`+'&a=b&c=d');
+    });
+
     it('should build startStreamerId', () => {
       let args = new DataFilterArgs();
       args.filter = streamSlugMock;

--- a/src/test/models/datafilterargs.spec.ts
+++ b/src/test/models/datafilterargs.spec.ts
@@ -24,6 +24,9 @@ describe('DataFilterArgsTest', () => {
     expect(filter_string).toEqual("?start=2016-09-13T20:29:13.825Z&end=2016-10-13T20:29:13.825Z");
     args.page = 2;
     expect(args.buildFilterString()).toEqual("?start=2016-09-13T20:29:13.825Z&end=2016-10-13T20:29:13.825Z&page=2");
+    args.pageSize=10000;
+    args.page = null;
+    expect(args.buildFilterString()).toEqual("?start=2016-09-13T20:29:13.825Z&end=2016-10-13T20:29:13.825Z&page_size=10000");
   });
 
   describe('check buildFilterString()', () => {
@@ -53,11 +56,6 @@ describe('DataFilterArgsTest', () => {
       let end = args.endDate.toISOString();
       expect(filter_string).toEqual(`?end=`+end+`&streamer_id_1=${args.endIncrementalId}`);
     });
-  });
-
-  it('check buildFilterString() for endStreamerId', () => {
-    let args: DataFilterArgs = new DataFilterArgs();
-
   });
 
   it('check buildFilterLabel() or dates', () => {


### PR DESCRIPTION
- pageSize can be used to force the get to get more entries per page
- extras can be used as an internal way to force additional arguments. In particular, we will be able to use this one to pass `staff=1` to allow us to get data even if we are not members of the Org